### PR TITLE
Fix a runtime error of the Jetconf container

### DIFF
--- a/mininet/Dockerfile_jetconf
+++ b/mininet/Dockerfile_jetconf
@@ -11,9 +11,10 @@ RUN apt-get -y update && apt-get -y upgrade && \
     # mysql-server \
     php-mysql php-fpm php-cli php-mysqlnd php-pgsql php-sqlite3 \
     php-redis php-apcu php-intl php-imagick php-json php-gd php-curl \
-    python3.6 python3-pip build-essential nghttp2 libnghttp2-dev \
+    python3.8 python3-pip build-essential nghttp2 libnghttp2-dev \
     libssl-dev make git
 
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
 RUN pip install numpy==1.14.6 MySQL-python
 
 ADD ./SecurityController /home/ubuntu/


### PR DESCRIPTION
There was a runtime error because of python version.
```
i2nsfjetconf    |   File "/usr/lib/python3.6/runpy.py", line 96, in _run_module_code
i2nsfjetconf    |     mod_name, mod_spec, pkg_name, script_name)
i2nsfjetconf    |   File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
i2nsfjetconf    |     exec(code, run_globals)
i2nsfjetconf    |   File "/home/ubuntu/works/jetconf/jetconf/__main__.py", line 13, in <module>
i2nsfjetconf    |     from yangson.enumerations import ContentType, ValidationScope
i2nsfjetconf    |   File "/usr/local/lib/python3.6/dist-packages/yangson/__init__.py", line 1, in <module>
i2nsfjetconf    |     from .datamodel import DataModel    # NOQA
i2nsfjetconf    |   File "/usr/local/lib/python3.6/dist-packages/yangson/datamodel.py", line 25
i2nsfjetconf    |     from __future__ import annotations
i2nsfjetconf    |     ^
i2nsfjetconf    | SyntaxError: future feature annotations is not defined
```